### PR TITLE
Added ability To Create Notes in Folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Create Journals and Notes in VS Code. Sync to your remote repository.
 Open the command runner: `cmd + p + >`
 
 1. VSJournal: Journal
-2. VSJournal: Create a New Note'
-3. VSJournal: Set Git Remote
-4. VSJournal: Sync Remote Git
+2. VSJournal: Create a New Note
+3. VSJournal: Create a New Note in Folder
+4. VSJournal: Set Git Remote
+5. VSJournal: Sync Remote Git

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
         "title": "VSJournal: Create New Note"
       },
       {
+        "command": "extension.createNoteInFolder",
+        "title": "VSJournal: Create New Note in Folder"
+      },
+      {
         "command": "extension.setGitRemote",
         "title": "VSJournal: Set Git Remote"
       },

--- a/package.json
+++ b/package.json
@@ -29,10 +29,6 @@
         "title": "VSJournal: Create New Note"
       },
       {
-        "command": "extension.createNoteInFolder",
-        "title": "VSJournal: Create New Note in Folder"
-      },
-      {
         "command": "extension.setGitRemote",
         "title": "VSJournal: Set Git Remote"
       },


### PR DESCRIPTION

### Description

This pull request introduces a new feature to the VSJournal extension, allowing users to create a new note inside a specified folder. The new command, `VSJournal: Create New Note in Folder`, enhances the existing functionality by providing better organisation and structure for journal entries.

### Changes

1. **New Command Implementation**
   - Added a new command `VSJournal: Create New Note in Folder` to the extension.
   - This command prompts the user to select or create a folder, then creates a new note inside the chosen folder.

2. **UI Enhancements**
   - Updated the command palette to include the new command.
   - Added a folder selection dialog to allow users to specify the target folder for the new note defaulting to the workspace directory of the VS code project.

3. **Code Modifications**
   - Modified the command registration in `extension.js` to include the new command.
   - Implemented folder selection and note creation logic in a new function `disposableCreateNoteInFolder` within `extension.js`.

4. **Documentation**
   - Updated the extension's README.md to include instructions for using the new command.

### How to Test

1. Open VS Code with the VSJournal extension installed.
2. Open the command palette (Ctrl+Shift+P or Cmd+Shift+P).
3. Type and select `VSJournal: Create New Note in Folder`.
4. Choose an existing folder or create a new one in the dialog that appears.
5. Verify that a new note is created inside the selected folder with the appropriate naming convention.

### Screenshots

![Folder Seelection Dialog](https://github.com/indrajithi/vs-journal/assets/22613186/f8e9fe2d-6c2c-4b87-a84d-f536b6fd27bf)
*Screenshot of the folder selection dialog.*

![Screenshot 2024-06-03 at 10 15 36](https://github.com/indrajithi/vs-journal/assets/22613186/5c76bb0d-19b1-4ae7-aab1-ae37261e2907)
*Screenshot of a new note created inside a folder.*

---

### Review Checklist

- [x] Code changes are tested and verified.
- [x] Documentation is updated accordingly.
- [x] No breaking changes are introduced.

---

Please review the changes and provide feedback. Looking forward to your inputs and suggestions!

Thank you!